### PR TITLE
Fix panic in walkLabelMatchers

### DIFF
--- a/promqlsmith.go
+++ b/promqlsmith.go
@@ -69,7 +69,7 @@ OUTER:
 	}
 	return &PromQLSmith{
 		rnd:              rnd,
-		seriesSet:        seriesSet,
+		seriesSet:        filterEmptySeries(seriesSet),
 		labelNames:       labelNamesFromLabelSet(seriesSet),
 		enableOffset:     enableOffset,
 		enableAtModifier: enableAtModifier,
@@ -138,6 +138,17 @@ func (s *PromQLSmith) Walk(valueTypes ...parser.ValueType) parser.Expr {
 	e := supportedExprs[s.rnd.Intn(len(supportedExprs))]
 	expr, _ := s.walkExpr(e, valueTypes...)
 	return expr
+}
+
+func filterEmptySeries(seriesSet []labels.Labels) []labels.Labels {
+	output := make([]labels.Labels, 0, len(seriesSet))
+	for _, lbls := range seriesSet {
+		if lbls.IsEmpty() {
+			continue
+		}
+		output = append(output, lbls)
+	}
+	return output
 }
 
 func labelNamesFromLabelSet(labelSet []labels.Labels) []string {

--- a/promqlsmith_test.go
+++ b/promqlsmith_test.go
@@ -1,6 +1,7 @@
 package promqlsmith
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -75,4 +76,33 @@ func TestWalk(t *testing.T) {
 	result := expr.Pretty(0)
 	_, err := parser.ParseExpr(result)
 	require.NoError(t, err)
+}
+
+func TestFilterEmptySeries(t *testing.T) {
+	for i, tc := range []struct {
+		ss       []labels.Labels
+		expected []labels.Labels
+	}{
+		{
+			ss:       nil,
+			expected: []labels.Labels{},
+		},
+		{
+			ss:       []labels.Labels{labels.EmptyLabels()},
+			expected: []labels.Labels{},
+		},
+		{
+			ss:       []labels.Labels{labels.FromStrings("foo", "bar")},
+			expected: []labels.Labels{labels.FromStrings("foo", "bar")},
+		},
+		{
+			ss:       testSeriesSet,
+			expected: testSeriesSet,
+		},
+	} {
+		t.Run(fmt.Sprintf("test_case_%d", i), func(t *testing.T) {
+			output := filterEmptySeries(tc.ss)
+			require.Equal(t, tc.expected, output)
+		})
+	}
 }

--- a/walk_test.go
+++ b/walk_test.go
@@ -373,22 +373,39 @@ func TestWalkAggregateExpr(t *testing.T) {
 func TestWalkVectorSelector(t *testing.T) {
 	rnd := rand.New(rand.NewSource(time.Now().Unix()))
 	p := New(rnd, testSeriesSet, true, true)
-	expr, lbls := p.walkVectorSelector()
+	expr := p.walkVectorSelector()
 	vs, ok := expr.(*parser.VectorSelector)
 	require.True(t, ok)
 	for _, matcher := range vs.LabelMatchers {
 		require.Equal(t, labels.MatchEqual, matcher.Type)
-		require.Equal(t, lbls.Get(matcher.Name), matcher.Value)
 	}
 }
 
 func TestWalkLabelMatchers(t *testing.T) {
 	rnd := rand.New(rand.NewSource(time.Now().Unix()))
-	p := New(rnd, testSeriesSet, true, true)
-	matchers, lbls := p.walkLabelMatchers()
-	for _, matcher := range matchers {
-		require.Equal(t, labels.MatchEqual, matcher.Type)
-		require.Equal(t, lbls.Get(matcher.Name), matcher.Value)
+	for i, tc := range []struct {
+		ss []labels.Labels
+	}{
+		{
+			ss: nil,
+		},
+		{
+			ss: []labels.Labels{labels.EmptyLabels()},
+		},
+		{
+			ss: []labels.Labels{labels.FromStrings("foo", "bar")},
+		},
+		{
+			ss: testSeriesSet,
+		},
+	} {
+		t.Run(fmt.Sprintf("test_case_%d", i), func(t *testing.T) {
+			p := New(rnd, tc.ss, true, true)
+			matchers := p.walkLabelMatchers()
+			for _, matcher := range matchers {
+				require.Equal(t, labels.MatchEqual, matcher.Type)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes panic when calling `walkLabelMatchers`. We need to make sure the input series is not empty.

```
--- FAIL: TestVerticalShardingFuzz (8.17s)
panic: invalid argument to Intn [recovered]
	panic: invalid argument to Intn

goroutine 79 [running]:
testing.tRunner.func1.2({0x11f9420, 0x176a5e0})
	/opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:1529 +0x39f
panic({0x11f9420, 0x176a5e0})
	/opt/hostedtoolcache/go/1.20.1/x64/src/runtime/panic.go:884 +0x213
math/rand.(*Rand).Intn(0x139cf00?, 0x0?)
	/opt/hostedtoolcache/go/1.20.1/x64/src/math/rand/rand.go:179 +0x65
github.com/cortexproject/promqlsmith.(*PromQLSmith).walkLabelMatchers(0xc00072adc0)
	/home/runner/work/cortex/cortex/vendor/github.com/cortexproject/promqlsmith/walk.go:218 +0x97
github.com/cortexproject/promqlsmith.(*PromQLSmith).walkVectorSelector(0xc00072adc0)
	/home/runner/work/cortex/cortex/vendor/github.com/cortexproject/promqlsmith/walk.go:200 +0x38
github.com/cortexproject/promqlsmith.(*PromQLSmith).walkMatrixSelector(0xc00072adc0)
	/home/runner/work/cortex/cortex/vendor/github.com/cortexproject/promqlsmith/walk.go:241 +0x25
github.com/cortexproject/promqlsmith.(*PromQLSmith).walkExpr(0xc00092b908?, 0xc00092b8d8?, {0xc00092bd10?, 0x6?, 0x10?})
	/home/runner/work/cortex/cortex/vendor/github.com/cortexproject/promqlsmith/walk.go:30 +0x4c
github.com/cortexproject/promqlsmith.(*PromQLSmith).Walk(0xc00072adc0, {0xc00092bd10?, 0x3, 0x3})
	/home/runner/work/cortex/cortex/vendor/github.com/cortexproject/promqlsmith/promqlsmith.go:139 +0x125
github.com/cortexproject/promqlsmith.(*PromQLSmith).WalkInstantQuery(...)
	/home/runner/work/cortex/cortex/vendor/github.com/cortexproject/promqlsmith/promqlsmith.go:124
github.com/cortexproject/cortex/integration.TestVerticalShardingFuzz(0xc0007a24e0)
	/home/runner/work/cortex/cortex/integration/query_fuzz_test.go:129 +0x1592
testing.tRunner(0xc0007a24e0, 0x14971d0)
	/opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:1576 +0x10b
created by testing.(*T).Run
	/opt/hostedtoolcache/go/1.20.1/x64/src/testing/testing.go:1[62](https://github.com/cortexproject/cortex/actions/runs/4369430062/jobs/7643282414#step:10:63)9 +0x3ea
FAIL	github.com/cortexproject/cortex/integration	8.211s
```