### PR TITLE
Always include metric name label for vector selector label matchers

### DIFF
--- a/walk_test.go
+++ b/walk_test.go
@@ -388,9 +388,14 @@ func TestWalkVectorSelector(t *testing.T) {
 	expr := p.walkVectorSelector()
 	vs, ok := expr.(*parser.VectorSelector)
 	require.True(t, ok)
+	containsMetricName := false
 	for _, matcher := range vs.LabelMatchers {
 		require.Equal(t, labels.MatchEqual, matcher.Type)
+		if matcher.Name == labels.MetricName {
+			containsMetricName = true
+		}
 	}
+	require.Equal(t, containsMetricName, true)
 }
 
 func TestWalkLabelMatchers(t *testing.T) {


### PR DESCRIPTION
This helps avoiding high cardinality and potential grouping errors.