### PR TITLE
Support vector matching in binary expression

### DIFF
--- a/example/demo/main.go
+++ b/example/demo/main.go
@@ -94,6 +94,7 @@ func run() error {
 		promqlsmith.WithEnableAtModifier(true),
 		promqlsmith.WithEnabledFunctions(getAvailableFunctions()),
 		promqlsmith.WithEnabledBinOps(enabledBinops),
+		promqlsmith.WithEnableVectorMatching(true),
 	}
 	ps := promqlsmith.New(rnd, modelLabelSetToLabels(series), opts...)
 	expr := ps.WalkInstantQuery()

--- a/example/thanos-engine/compatibility_test.go
+++ b/example/thanos-engine/compatibility_test.go
@@ -57,6 +57,7 @@ http_requests_total{pod="nginx-6", series="2"} 2.3+2.3x50
 	psOpts := []promqlsmith.Option{
 		promqlsmith.WithEnableOffset(true),
 		promqlsmith.WithEnableAtModifier(true),
+		promqlsmith.WithEnableVectorMatching(true),
 	}
 	ps := promqlsmith.New(rnd, series, psOpts...)
 
@@ -64,7 +65,6 @@ http_requests_total{pod="nginx-6", series="2"} 2.3+2.3x50
 		expr := ps.WalkInstantQuery()
 		query := expr.Pretty(0)
 		t.Logf("Running instant query %s\n", query)
-		//level.Info(logger).Log("msg", "start running instant query", "query", query)
 		q1, err := oldEngine.NewInstantQuery(test.Queryable(), nil, query, now)
 		testutil.Ok(t, err)
 

--- a/opts.go
+++ b/opts.go
@@ -72,8 +72,9 @@ type options struct {
 	enabledFuncs  []*parser.Function
 	enabledBinops []parser.ItemType
 
-	enableOffset     bool
-	enableAtModifier bool
+	enableOffset         bool
+	enableAtModifier     bool
+	enableVectorMatching bool
 }
 
 func (o *options) applyDefaults() {
@@ -114,6 +115,12 @@ func WithEnableOffset(enableOffset bool) Option {
 func WithEnableAtModifier(enableAtModifier bool) Option {
 	return optionFunc(func(o *options) {
 		o.enableAtModifier = enableAtModifier
+	})
+}
+
+func WithEnableVectorMatching(enableVectorMatching bool) Option {
+	return optionFunc(func(o *options) {
+		o.enableVectorMatching = enableVectorMatching
 	})
 }
 

--- a/promqlsmith.go
+++ b/promqlsmith.go
@@ -40,8 +40,9 @@ var (
 type PromQLSmith struct {
 	rnd *rand.Rand
 
-	enableOffset     bool
-	enableAtModifier bool
+	enableOffset         bool
+	enableAtModifier     bool
+	enableVectorMatching bool
 
 	seriesSet  []labels.Labels
 	labelNames []string
@@ -61,15 +62,16 @@ func New(rnd *rand.Rand, seriesSet []labels.Labels, opts ...Option) *PromQLSmith
 	options.applyDefaults()
 
 	ps := &PromQLSmith{
-		rnd:              rnd,
-		seriesSet:        filterEmptySeries(seriesSet),
-		labelNames:       labelNamesFromLabelSet(seriesSet),
-		supportedExprs:   options.enabledExprs,
-		supportedAggrs:   options.enabledAggrs,
-		supportedBinops:  options.enabledBinops,
-		supportedFuncs:   options.enabledFuncs,
-		enableOffset:     options.enableOffset,
-		enableAtModifier: options.enableAtModifier,
+		rnd:                  rnd,
+		seriesSet:            filterEmptySeries(seriesSet),
+		labelNames:           labelNamesFromLabelSet(seriesSet),
+		supportedExprs:       options.enabledExprs,
+		supportedAggrs:       options.enabledAggrs,
+		supportedBinops:      options.enabledBinops,
+		supportedFuncs:       options.enabledFuncs,
+		enableOffset:         options.enableOffset,
+		enableAtModifier:     options.enableAtModifier,
+		enableVectorMatching: options.enableVectorMatching,
 	}
 	return ps
 }

--- a/walk.go
+++ b/walk.go
@@ -3,12 +3,16 @@ package promqlsmith
 import (
 	"fmt"
 	"math/rand"
+	"sort"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
 	"golang.org/x/exp/slices"
 )
+
+var empty = labels.EmptyLabels()
 
 const (
 	// max number of grouping labels in either by or without clause.
@@ -90,15 +94,16 @@ func (s *PromQLSmith) walkBinaryExpr(valueTypes ...parser.ValueType) parser.Expr
 		valueTypes = vectorAndScalarValueTypes
 	}
 	expr := &parser.BinaryExpr{
-		Op:             s.walkBinaryOp(!slices.Contains(valueTypes, parser.ValueTypeVector)),
-		VectorMatching: &parser.VectorMatching{},
+		Op: s.walkBinaryOp(!slices.Contains(valueTypes, parser.ValueTypeVector)),
+		VectorMatching: &parser.VectorMatching{
+			Card: parser.CardOneToOne,
+		},
 	}
 	// If it is a set operator then only vectors are allowed.
 	if expr.Op.IsSetOperator() {
 		valueTypes = []parser.ValueType{parser.ValueTypeVector}
 		expr.VectorMatching.Card = parser.CardManyToMany
 	}
-	// TODO: support vector matching types.
 	expr.LHS = wrapParenExpr(s.Walk(valueTypes...))
 	expr.RHS = wrapParenExpr(s.Walk(valueTypes...))
 	lvt := expr.LHS.Type()
@@ -110,7 +115,82 @@ func (s *PromQLSmith) walkBinaryExpr(valueTypes ...parser.ValueType) parser.Expr
 			expr.ReturnBool = true
 		}
 	}
+
+	if !expr.Op.IsSetOperator() && s.enableVectorMatching && lvt == parser.ValueTypeVector &&
+		rvt == parser.ValueTypeVector && s.rnd.Intn(2) == 0 {
+		leftSeriesSet, stop := getOutputSeries(expr.LHS)
+		if stop {
+			return expr
+		}
+		rightSeriesSet, stop := getOutputSeries(expr.RHS)
+		if stop {
+			return expr
+		}
+		s.walkVectorMatching(expr, leftSeriesSet, rightSeriesSet, s.rnd.Intn(4) == 0)
+	}
 	return expr
+}
+
+func (s *PromQLSmith) walkVectorMatching(expr *parser.BinaryExpr, seriesSetA []labels.Labels, seriesSetB []labels.Labels, includeLabels bool) {
+	sa := make(map[string]struct{})
+	for _, series := range seriesSetA {
+		for _, lbl := range series {
+			if lbl.Name == labels.MetricName {
+				continue
+			}
+			sa[lbl.Name] = struct{}{}
+		}
+	}
+
+	sb := make(map[string]struct{})
+	for _, series := range seriesSetB {
+		for _, lbl := range series {
+			if lbl.Name == labels.MetricName {
+				continue
+			}
+			sb[lbl.Name] = struct{}{}
+		}
+	}
+	expr.VectorMatching.On = true
+	matchedLabels := make([]string, 0)
+	for key := range sb {
+		if _, ok := sa[key]; ok {
+			matchedLabels = append(matchedLabels, key)
+		}
+	}
+	// We are doing a very naive approach of guessing side cardinalities
+	// by checking number of series each side.
+	oneSideLabelsSet := sa
+	if len(seriesSetA) > len(seriesSetB) {
+		expr.VectorMatching.MatchingLabels = matchedLabels
+		expr.VectorMatching.Card = parser.CardManyToOne
+		oneSideLabelsSet = sb
+	} else if len(seriesSetA) < len(seriesSetB) {
+		expr.VectorMatching.MatchingLabels = matchedLabels
+		expr.VectorMatching.Card = parser.CardOneToMany
+	}
+	// Otherwise we do 1:1 match.
+
+	// For simplicity, we always include all labels on the one side.
+	if expr.VectorMatching.Card != parser.CardOneToOne && includeLabels {
+		includeLabels := getIncludeLabels(oneSideLabelsSet, matchedLabels)
+		expr.VectorMatching.Include = includeLabels
+	}
+}
+
+func getIncludeLabels(labelNameSet map[string]struct{}, matchedLabels []string) []string {
+	output := make([]string, 0)
+OUTER:
+	for lbl := range labelNameSet {
+		for _, matchedLabel := range matchedLabels {
+			if lbl == matchedLabel {
+				continue OUTER
+			}
+		}
+		output = append(output, lbl)
+	}
+	sort.Strings(output)
+	return output
 }
 
 // Walk binary op based on whether vector value type is allowed or not.
@@ -191,6 +271,7 @@ func (s *PromQLSmith) walkHoltWinters(expr *parser.Call) {
 func (s *PromQLSmith) walkVectorSelector() parser.Expr {
 	expr := &parser.VectorSelector{}
 	expr.LabelMatchers = s.walkLabelMatchers()
+	s.populateSeries(expr)
 	if s.enableOffset && s.rnd.Int()%2 == 0 {
 		negativeOffset := s.rnd.Intn(2) == 0
 		expr.OriginalOffset = time.Duration(s.rnd.Intn(300)) * time.Second
@@ -203,6 +284,20 @@ func (s *PromQLSmith) walkVectorSelector() parser.Expr {
 	}
 
 	return expr
+}
+
+func (s *PromQLSmith) populateSeries(expr *parser.VectorSelector) {
+	expr.Series = make([]storage.Series, 0)
+OUTER:
+	for _, series := range s.seriesSet {
+		for _, matcher := range expr.LabelMatchers {
+			m := matcher
+			if !m.Matches(series.Get(m.Name)) {
+				continue OUTER
+			}
+		}
+		expr.Series = append(expr.Series, &storage.SeriesEntry{Lset: series})
+	}
 }
 
 func (s *PromQLSmith) walkLabelMatchers() []*labels.Matcher {
@@ -327,4 +422,108 @@ func getNonZeroFloat64(rnd *rand.Rand) float64 {
 		}
 		return res
 	}
+}
+
+// Get output series for the expr using best-effort guess. This can be used in fuzzing
+// vector matching. A bool value will also be returned alongside with the output series.
+// This is used to determine whether the expression is suitable to do vector matching or not.
+func getOutputSeries(expr parser.Expr) ([]labels.Labels, bool) {
+	stop := false
+	var lbls []labels.Labels
+	switch node := (expr).(type) {
+	case *parser.VectorSelector:
+		lbls := make([]labels.Labels, len(node.Series))
+		for i, s := range node.Series {
+			lbls[i] = s.Labels()
+		}
+		return lbls, len(lbls) == 0
+	case *parser.StepInvariantExpr:
+		return getOutputSeries(node.Expr)
+	case *parser.MatrixSelector:
+		return getOutputSeries(node.VectorSelector)
+	case *parser.ParenExpr:
+		return getOutputSeries(node.Expr)
+	case *parser.UnaryExpr:
+		return getOutputSeries(node.Expr)
+	case *parser.NumberLiteral:
+		return nil, false
+	case *parser.StringLiteral:
+		return nil, false
+	case *parser.AggregateExpr:
+		lbls, stop = getOutputSeries(node.Expr)
+		if stop {
+			return nil, true
+		}
+
+		m := make(map[uint64]labels.Labels)
+		b := make([]byte, 1024)
+		output := make([]labels.Labels, 0)
+		lb := labels.NewBuilder(nil)
+		if !node.Without {
+			for _, lbl := range lbls {
+				for _, groupLabel := range node.Grouping {
+					if val := lbl.Get(groupLabel); val == "" {
+						continue
+					} else {
+						lb.Set(groupLabel, val)
+					}
+				}
+				newLbl := lb.Labels(empty)
+				h, _ := newLbl.HashForLabels(b, node.Grouping...)
+				if _, ok := m[h]; !ok {
+					m[h] = newLbl
+				}
+			}
+		} else {
+			set := make(map[string]struct{})
+			for _, g := range node.Grouping {
+				set[g] = struct{}{}
+			}
+			for _, lbl := range lbls {
+				for _, l := range lbl {
+					if l.Name == labels.MetricName {
+						continue
+					}
+					if _, ok := set[l.Name]; !ok {
+						if val := lbl.Get(l.Name); val == "" {
+							continue
+						} else {
+							lb.Set(l.Name, val)
+						}
+					}
+				}
+
+				newLbl := lb.Labels(empty)
+				h, _ := newLbl.HashWithoutLabels(b, node.Grouping...)
+				if _, ok := m[h]; !ok {
+					m[h] = newLbl
+				}
+			}
+		}
+
+		for _, v := range m {
+			output = append(output, v)
+		}
+		return output, false
+	case *parser.SubqueryExpr:
+		return getOutputSeries(node.Expr)
+	case *parser.BinaryExpr:
+		// Stop introducing complexity if there is a binary expr already.
+		return nil, true
+	case *parser.Call:
+		// For function, we ignore `absent` and `absent_over_time`. And we continue
+		// traversal by checking the first matrix or vector argument.
+		if node.Func.Name == "absent" || node.Func.Name == "absent_over_time" {
+			return nil, true
+		}
+		for i, arg := range node.Func.ArgTypes {
+			// Find first matrix or vector type parameter, and we only
+			// check series from it.
+			if arg == parser.ValueTypeMatrix || arg == parser.ValueTypeVector {
+				return getOutputSeries(node.Args[i])
+			}
+		}
+		return nil, false
+	}
+	return lbls, stop
 }


### PR DESCRIPTION
Fixes https://github.com/cortexproject/promqlsmith/issues/3.

This is still experimental and has potentially performance impact during fuzzing as it currently tries to find matched series and calculate the result series labels in memory.
By having the result series labels information, then the fuzzer is able to guess (though still naive) the cardinality of left and right hand side.
Currently it guesses this by checking the number of series they may have, but this is still kind of inaccurate sometimes so it may generate bad queries.