### PR TITLE
Max at modifier timestamp

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -77,7 +77,7 @@ type options struct {
 	enableOffset           bool
 	enableAtModifier       bool
 	enableVectorMatching   bool
-	maxAtModifierTimestamp int64
+	atModifierMaxTimestamp int64
 }
 
 func (o *options) applyDefaults() {
@@ -97,8 +97,8 @@ func (o *options) applyDefaults() {
 		o.enabledFuncs = defaultSupportedFuncs
 	}
 
-	if o.maxAtModifierTimestamp == 0 {
-		o.maxAtModifierTimestamp = time.Now().UnixMilli()
+	if o.atModifierMaxTimestamp == 0 {
+		o.atModifierMaxTimestamp = time.Now().UnixMilli()
 	}
 }
 
@@ -119,9 +119,9 @@ func WithEnableOffset(enableOffset bool) Option {
 	})
 }
 
-func WithMaxAtModifierTimestamp(maxAtModifierTimestamp int64) Option {
+func WithAtModifierMaxTimestamp(atModifierMaxTimestamp int64) Option {
 	return optionFunc(func(o *options) {
-		o.maxAtModifierTimestamp = maxAtModifierTimestamp
+		o.atModifierMaxTimestamp = atModifierMaxTimestamp
 	})
 }
 

--- a/opts.go
+++ b/opts.go
@@ -1,6 +1,8 @@
 package promqlsmith
 
 import (
+	"time"
+
 	"github.com/prometheus/prometheus/promql/parser"
 	"golang.org/x/exp/slices"
 )
@@ -72,9 +74,10 @@ type options struct {
 	enabledFuncs  []*parser.Function
 	enabledBinops []parser.ItemType
 
-	enableOffset         bool
-	enableAtModifier     bool
-	enableVectorMatching bool
+	enableOffset           bool
+	enableAtModifier       bool
+	enableVectorMatching   bool
+	maxAtModifierTimestamp int64
 }
 
 func (o *options) applyDefaults() {
@@ -93,6 +96,10 @@ func (o *options) applyDefaults() {
 	if len(o.enabledFuncs) == 0 {
 		o.enabledFuncs = defaultSupportedFuncs
 	}
+
+	if o.maxAtModifierTimestamp == 0 {
+		o.maxAtModifierTimestamp = time.Now().UnixMilli()
+	}
 }
 
 // Option specifies options when generating queries.
@@ -109,6 +116,12 @@ func (f optionFunc) apply(o *options) {
 func WithEnableOffset(enableOffset bool) Option {
 	return optionFunc(func(o *options) {
 		o.enableOffset = enableOffset
+	})
+}
+
+func WithMaxAtModifierTimestamp(maxAtModifierTimestamp int64) Option {
+	return optionFunc(func(o *options) {
+		o.maxAtModifierTimestamp = maxAtModifierTimestamp
 	})
 }
 

--- a/opts_test.go
+++ b/opts_test.go
@@ -29,9 +29,9 @@ func TestWithEnabledAggrs(t *testing.T) {
 func TestWithMaxAtModifierTimestamp(t *testing.T) {
 	o := &options{}
 	o.applyDefaults()
-	require.GreaterOrEqual(t, time.Now().UnixMilli(), o.maxAtModifierTimestamp)
-	WithMaxAtModifierTimestamp(time.UnixMilli(1000).UnixMilli()).apply(o)
-	require.Equal(t, int64(1000), o.maxAtModifierTimestamp)
+	require.GreaterOrEqual(t, time.Now().UnixMilli(), o.atModifierMaxTimestamp)
+	WithAtModifierMaxTimestamp(time.UnixMilli(1000).UnixMilli()).apply(o)
+	require.Equal(t, int64(1000), o.atModifierMaxTimestamp)
 }
 
 func TestWithEnabledBinOps(t *testing.T) {

--- a/opts_test.go
+++ b/opts_test.go
@@ -2,6 +2,7 @@ package promqlsmith
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,14 @@ func TestWithEnabledAggrs(t *testing.T) {
 	o := &options{}
 	WithEnabledAggrs([]parser.ItemType{parser.SUM}).apply(o)
 	require.Equal(t, []parser.ItemType{parser.SUM}, o.enabledAggrs)
+}
+
+func TestWithMaxAtModifierTimestamp(t *testing.T) {
+	o := &options{}
+	o.applyDefaults()
+	require.GreaterOrEqual(t, time.Now().UnixMilli(), o.maxAtModifierTimestamp)
+	WithMaxAtModifierTimestamp(time.UnixMilli(1000).UnixMilli()).apply(o)
+	require.Equal(t, int64(1000), o.maxAtModifierTimestamp)
 }
 
 func TestWithEnabledBinOps(t *testing.T) {

--- a/promqlsmith.go
+++ b/promqlsmith.go
@@ -43,7 +43,7 @@ type PromQLSmith struct {
 	enableOffset           bool
 	enableAtModifier       bool
 	enableVectorMatching   bool
-	maxAtModifierTimestamp int64
+	atModifierMaxTimestamp int64
 
 	seriesSet  []labels.Labels
 	labelNames []string
@@ -72,7 +72,7 @@ func New(rnd *rand.Rand, seriesSet []labels.Labels, opts ...Option) *PromQLSmith
 		supportedFuncs:         options.enabledFuncs,
 		enableOffset:           options.enableOffset,
 		enableAtModifier:       options.enableAtModifier,
-		maxAtModifierTimestamp: options.maxAtModifierTimestamp,
+		atModifierMaxTimestamp: options.atModifierMaxTimestamp,
 		enableVectorMatching:   options.enableVectorMatching,
 	}
 	return ps

--- a/promqlsmith.go
+++ b/promqlsmith.go
@@ -40,9 +40,10 @@ var (
 type PromQLSmith struct {
 	rnd *rand.Rand
 
-	enableOffset         bool
-	enableAtModifier     bool
-	enableVectorMatching bool
+	enableOffset           bool
+	enableAtModifier       bool
+	enableVectorMatching   bool
+	maxAtModifierTimestamp int64
 
 	seriesSet  []labels.Labels
 	labelNames []string
@@ -62,16 +63,17 @@ func New(rnd *rand.Rand, seriesSet []labels.Labels, opts ...Option) *PromQLSmith
 	options.applyDefaults()
 
 	ps := &PromQLSmith{
-		rnd:                  rnd,
-		seriesSet:            filterEmptySeries(seriesSet),
-		labelNames:           labelNamesFromLabelSet(seriesSet),
-		supportedExprs:       options.enabledExprs,
-		supportedAggrs:       options.enabledAggrs,
-		supportedBinops:      options.enabledBinops,
-		supportedFuncs:       options.enabledFuncs,
-		enableOffset:         options.enableOffset,
-		enableAtModifier:     options.enableAtModifier,
-		enableVectorMatching: options.enableVectorMatching,
+		rnd:                    rnd,
+		seriesSet:              filterEmptySeries(seriesSet),
+		labelNames:             labelNamesFromLabelSet(seriesSet),
+		supportedExprs:         options.enabledExprs,
+		supportedAggrs:         options.enabledAggrs,
+		supportedBinops:        options.enabledBinops,
+		supportedFuncs:         options.enabledFuncs,
+		enableOffset:           options.enableOffset,
+		enableAtModifier:       options.enableAtModifier,
+		maxAtModifierTimestamp: options.maxAtModifierTimestamp,
+		enableVectorMatching:   options.enableVectorMatching,
 	}
 	return ps
 }

--- a/walk.go
+++ b/walk.go
@@ -340,7 +340,7 @@ func (s *PromQLSmith) walkAtModifier() (ts *int64, op parser.ItemType) {
 	case 1:
 		op = parser.END
 	case 2:
-		t := time.Now().UnixMilli()
+		t := s.rnd.Int63n(s.maxAtModifierTimestamp)
 		ts = &t
 	}
 	return

--- a/walk.go
+++ b/walk.go
@@ -340,7 +340,7 @@ func (s *PromQLSmith) walkAtModifier() (ts *int64, op parser.ItemType) {
 	case 1:
 		op = parser.END
 	case 2:
-		t := s.rnd.Int63n(s.maxAtModifierTimestamp)
+		t := s.rnd.Int63n(s.atModifierMaxTimestamp)
 		ts = &t
 	}
 	return


### PR DESCRIPTION
Right now the `at` modifier is always being set to `time.now()` causing the selector to return empty if the tests does not have samples for that timestamp.

This PR introduce an extra parameter to set the max time to be set on the `@` modifier so we can make sure that the timestamp selected will contain samples.