### PR TITLE
fix unary expression generates bad query

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -89,9 +89,6 @@ func (s *PromQLSmith) walkAggregateParam(op parser.ItemType) parser.Expr {
 // or function that returns matrix.
 func (s *PromQLSmith) walkBinaryExpr(valueTypes ...parser.ValueType) parser.Expr {
 	valueTypes = keepValueTypes(valueTypes, vectorAndScalarValueTypes)
-	if len(valueTypes) == 0 {
-		valueTypes = vectorAndScalarValueTypes
-	}
 	expr := &parser.BinaryExpr{
 		Op: s.walkBinaryOp(!slices.Contains(valueTypes, parser.ValueTypeVector)),
 		VectorMatching: &parser.VectorMatching{
@@ -399,7 +396,11 @@ func wrapParenExpr(expr parser.Expr) parser.Expr {
 
 // keepValueTypes picks value types that we should keep from the input.
 // input shouldn't contain duplicate value types.
+// If no input value types are provided, use value types to keep as result.
 func keepValueTypes(input []parser.ValueType, keep []parser.ValueType) []parser.ValueType {
+	if len(input) == 0 {
+		return keep
+	}
 	out := make([]parser.ValueType, 0, len(keep))
 	s := make(map[parser.ValueType]struct{})
 	for _, vt := range keep {

--- a/walk_test.go
+++ b/walk_test.go
@@ -273,6 +273,11 @@ func TestKeepValueTypes(t *testing.T) {
 			expected: []parser.ValueType{},
 		},
 		{
+			input:    []parser.ValueType{},
+			keep:     vectorAndScalarValueTypes,
+			expected: vectorAndScalarValueTypes,
+		},
+		{
 			input:    []parser.ValueType{parser.ValueTypeMatrix},
 			keep:     []parser.ValueType{parser.ValueTypeMatrix},
 			expected: []parser.ValueType{parser.ValueTypeMatrix},


### PR DESCRIPTION
Error: https://github.com/cortexproject/promqlsmith/actions/runs/7524325164/job/20478965444?pr=90

```
=== RUN   TestWalk
    promqlsmith_test.go:84: 
        	Error Trace:	/home/runner/work/promqlsmith/promqlsmith/promqlsmith_test.go:84
        	Error:      	Received unexpected error:
        	            	1:1: parse error: unary expression only allowed on expressions of type scalar or instant vector, got "range vector"
        	Test:       	TestWalk
```