### PR TITLE
add support for label_join and label_replace function

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"golang.org/x/exp/slices"
 )
 
 var (
@@ -58,9 +57,6 @@ var (
 
 func init() {
 	for _, f := range parser.Functions {
-		if slices.Contains(f.ArgTypes, parser.ValueTypeString) {
-			continue
-		}
 		// Ignore experimental functions for now.
 		if !f.Experimental {
 			defaultSupportedFuncs = append(defaultSupportedFuncs, f)


### PR DESCRIPTION
Fixes #29, this PR adds fuzz support for `label_join` and `label_replace`.

The destination label is hardcoded to be `__promqlsmith_dst_label__` and it is expected for users to not use this label in their series.

The source labels used for join and replace are picked in random. Label join shouldn't have more than 2 labels for joining for simplicity.

```
label_join(<randomly generated vector selector>, "__promqlsmith_dst_label__", ",", "<source_label1>", "<source_label2>")
```

Label replace is only copying same label to target label for simplicity.

```
label_replace(<randomly generated vector selector>, "__promqlsmith_dst_label__", "$1", "<source_label>", "(.*)")
```