### PR TITLE
Disable at modifier to walkinfo

### DIFF
--- a/walk_test.go
+++ b/walk_test.go
@@ -492,7 +492,7 @@ func TestWalkVectorSelector(t *testing.T) {
 	rnd := rand.New(rand.NewSource(time.Now().Unix()))
 	opts := []Option{WithEnableOffset(true), WithEnableAtModifier(true)}
 	p := New(rnd, testSeriesSet, opts...)
-	expr := p.walkVectorSelector()
+	expr := p.walkVectorSelector(true)
 	vs, ok := expr.(*parser.VectorSelector)
 	require.True(t, ok)
 	containsMetricName := false


### PR DESCRIPTION
Disable `at modifier` to `walkinfo` function to prevent panic.

FYI. panic log in Prometheus
```
prometheus: ts=2024-11-21T01:31:32.562Z caller=engine.go:1089 level=error component="query engine" msg="runtime panic during query evaluation" expr="-ceil(info({__name__=\"test_series_a\",status_code=\"404\"}, {__name__=\"test_series_a\",job=\"test\"} @ 1732149073.310))" err="interface conversion: parser.Expr is *parser.StepInvariantExpr, not *parser.VectorSelector" stacktrace="goroutine 483 [running]:
```