### PR TITLE
Allowing to create Not/Regex/NotRegex matchers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,5 @@ jobs:
         with:
           go-version-file: .go-version
           cache: true
-      - name: Lint
-        uses: golangci/golangci-lint-action@v6.1.0
-        with:
-          version: v1.59.0
+      - name: Golangci-lint
+        uses: golangci/golangci-lint-action@v6.2.0

--- a/walk.go
+++ b/walk.go
@@ -2,6 +2,7 @@ package promqlsmith
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"sort"
 	"strings"
@@ -452,7 +453,7 @@ func (s *PromQLSmith) walkLabelMatchers() []*labels.Matcher {
 	}
 	series := s.seriesSet[s.rnd.Intn(len(s.seriesSet))]
 	orders := s.rnd.Perm(series.Len())
-	items := s.rnd.Intn((series.Len() + 1) / 2)
+	items := s.rnd.Intn(int(math.Ceil(float64(series.Len()+1) / 2)))
 	matchers := make([]*labels.Matcher, 0, items)
 	containsName := false
 	lbls := make([]labels.Label, 0, series.Len())

--- a/walk.go
+++ b/walk.go
@@ -720,13 +720,6 @@ func keepValueTypes(input []parser.ValueType, keep []parser.ValueType) []parser.
 	return out
 }
 
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 // generate a non-zero float64 value randomly.
 func getNonZeroFloat64(rnd *rand.Rand) float64 {
 	for {

--- a/walk.go
+++ b/walk.go
@@ -490,7 +490,11 @@ func (s *PromQLSmith) walkLabelMatchers() []*labels.Matcher {
 			case labels.MatchEqual:
 				matcher = labels.MustNewMatcher(labels.MatchEqual, lbls[orders[i]].Name, lbls[orders[i]].Value)
 			case labels.MatchNotEqual:
-				matcher = labels.MustNewMatcher(labels.MatchNotEqual, lbls[orders[i]].Name, lbls[orders[i]].Value)
+				val := lbls[orders[i]].Value
+				if s.rnd.Float64() > 0.9 {
+					val = ""
+				}
+				matcher = labels.MustNewMatcher(labels.MatchNotEqual, lbls[orders[i]].Name, val)
 			case labels.MatchRegexp:
 				matcher = labels.MustNewMatcher(labels.MatchRegexp, lbls[orders[i]].Name, valF(lbls[orders[i]].Value))
 			case labels.MatchNotRegexp:


### PR DESCRIPTION
Start creating Matchers other than just `equal` on the queries.

This will allow us to also test those cases.