### PR TITLE
Avoid panic if label value contains +

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -462,6 +462,11 @@ func (s *PromQLSmith) walkLabelMatchers() []*labels.Matcher {
 	})
 
 	valF := func(v string) string {
+		// If a label value contains + such as +Inf it will cause parse error for regex.
+		// Always hardcode to .+ for simplicity.
+		if strings.Contains(v, "+") {
+			return ".+"
+		}
 		val := s.rnd.Float64()
 		switch {
 		case val > 0.95:


### PR DESCRIPTION
This can happen when we generate regex matchers and the label value contains `+` such as `+Inf`.

Prometheus unable to handle this case when parsing the regex even today.

<img width="1503" alt="image" src="https://github.com/user-attachments/assets/2f3d014e-3ca4-4b51-adce-720ca3df41f1" />

Hardcode to return `.+` for simplicity.