### PR TITLE
Support expression generation depth

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -15,6 +15,7 @@ var (
 		AggregateExpr,
 		SubQueryExpr,
 		CallExpr,
+		NumberLiteral,
 		UnaryExpr,
 	}
 
@@ -85,6 +86,8 @@ type options struct {
 	atModifierMaxTimestamp            int64
 
 	enforceLabelMatchers []*labels.Matcher
+
+	maxDepth int // Maximum depth of the query expression tree
 }
 
 func (o *options) applyDefaults() {
@@ -111,6 +114,10 @@ func (o *options) applyDefaults() {
 
 	if o.atModifierMaxTimestamp == 0 {
 		o.atModifierMaxTimestamp = time.Now().UnixMilli()
+	}
+
+	if o.maxDepth == 0 {
+		o.maxDepth = 5 // Default max depth
 	}
 }
 
@@ -182,5 +189,12 @@ func WithEnabledExprs(enabledExprs []ExprType) Option {
 func WithEnforceLabelMatchers(matchers []*labels.Matcher) Option {
 	return optionFunc(func(o *options) {
 		o.enforceLabelMatchers = matchers
+	})
+}
+
+// WithMaxDepth sets the maximum depth for generated query expressions
+func WithMaxDepth(depth int) Option {
+	return optionFunc(func(o *options) {
+		o.maxDepth = depth
 	})
 }

--- a/opts_test.go
+++ b/opts_test.go
@@ -64,3 +64,14 @@ func TestWithEnabledFunctions(t *testing.T) {
 	WithEnabledFunctions([]*parser.Function{parser.Functions["absent"]}).apply(o)
 	require.Equal(t, []*parser.Function{parser.Functions["absent"]}, o.enabledFuncs)
 }
+
+func TestWithMaxDepth(t *testing.T) {
+	o := &options{}
+	WithMaxDepth(3).apply(o)
+	require.Equal(t, 3, o.maxDepth)
+
+	// Test default value
+	o = &options{}
+	o.applyDefaults()
+	require.Equal(t, 5, o.maxDepth) // Default depth
+}

--- a/promqlsmith.go
+++ b/promqlsmith.go
@@ -1,6 +1,7 @@
 package promqlsmith
 
 import (
+	"fmt"
 	"math/rand"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -19,6 +20,18 @@ const (
 	NumberLiteral
 	UnaryExpr
 )
+
+// Add minimum depth requirements for each ExprType
+var exprMinDepth = map[ExprType]int{
+	VectorSelector: 1,
+	MatrixSelector: 1, // Needs one child expression but we consider 1 depth
+	AggregateExpr:  2, // Needs at least one child expression
+	BinaryExpr:     2, // Needs two child expressions but whichever higher
+	SubQueryExpr:   2, // Needs one child expression
+	CallExpr:       2, // Needs at least one argument
+	NumberLiteral:  1,
+	UnaryExpr:      2, // Needs one child expression
+}
 
 var (
 	valueTypeToExprsMap = map[parser.ValueType][]ExprType{
@@ -45,6 +58,7 @@ type PromQLSmith struct {
 	enableVectorMatching     bool
 	enableExperimentalPromQL bool
 	atModifierMaxTimestamp   int64
+	maxDepth                 int
 
 	seriesSet       []labels.Labels
 	labelNames      []string
@@ -78,6 +92,7 @@ func New(rnd *rand.Rand, seriesSet []labels.Labels, opts ...Option) *PromQLSmith
 		enableVectorMatching:     options.enableVectorMatching,
 		enableExperimentalPromQL: options.enableExperimentalPromQLFunctions,
 		enforceMatchers:          options.enforceLabelMatchers,
+		maxDepth:                 options.maxDepth,
 	}
 	ps.labelNames, ps.labelValues = labelNameAndValuesFromLabelSet(seriesSet)
 	return ps
@@ -99,14 +114,63 @@ func (s *PromQLSmith) WalkSelectors() []*labels.Matcher {
 	return s.walkSelectors()
 }
 
+// intersectExprTypes returns the intersection of two ExprType slices
+func intersectExprTypes(a, b []ExprType) []ExprType {
+	result := make([]ExprType, 0)
+	for _, expr := range a {
+		for _, other := range b {
+			if expr == other {
+				result = append(result, expr)
+				break
+			}
+		}
+	}
+	return result
+}
+
 // Walk will walk the ast tree using one of the randomly generated expr type.
 func (s *PromQLSmith) Walk(valueTypes ...parser.ValueType) parser.Expr {
+	return s.walk(s.maxDepth, valueTypes...)
+}
+
+// filterNumberLiteral removes NumberLiteral from validExprs unless it's the only option
+func filterNumberLiteral(validExprs []ExprType) []ExprType {
+	if len(validExprs) <= 1 {
+		return validExprs
+	}
+
+	filtered := make([]ExprType, 0, len(validExprs))
+	for _, expr := range validExprs {
+		if expr != NumberLiteral {
+			filtered = append(filtered, expr)
+		}
+	}
+	return filtered
+}
+
+func (s *PromQLSmith) walk(depth int, valueTypes ...parser.ValueType) parser.Expr {
 	supportedExprs := s.supportedExprs
 	if len(valueTypes) > 0 {
-		supportedExprs = exprsFromValueTypes(valueTypes)
+		supportedExprs = intersectExprTypes(supportedExprs, exprsFromValueTypes(valueTypes))
 	}
-	e := supportedExprs[s.rnd.Intn(len(supportedExprs))]
-	expr, _ := s.walkExpr(e, valueTypes...)
+
+	// Filter expressions based on remaining depth
+	validExprs := make([]ExprType, 0, len(supportedExprs))
+	for _, expr := range supportedExprs {
+		if minDepth := exprMinDepth[expr]; depth >= minDepth {
+			validExprs = append(validExprs, expr)
+		}
+	}
+
+	// Return nil if no valid expressions are available
+	if len(validExprs) == 0 {
+		fmt.Println("no valid exprs", depth, s.supportedExprs, valueTypes, supportedExprs, validExprs)
+		return nil
+	}
+
+	validExprs = filterNumberLiteral(validExprs)
+	e := validExprs[s.rnd.Intn(len(validExprs))]
+	expr, _ := s.walkExpr(e, depth, valueTypes...)
 	return expr
 }
 

--- a/promqlsmith_test.go
+++ b/promqlsmith_test.go
@@ -178,3 +178,151 @@ func TestFilterEmptySeries(t *testing.T) {
 		})
 	}
 }
+
+func TestPromQLSmith_Walk_RespectsExprAndValueTypeConstraints(t *testing.T) {
+	tests := []struct {
+		name           string
+		supportedExprs []ExprType
+		valueTypes     []parser.ValueType
+		wantNil        bool
+	}{
+		{
+			name:           "vector only expressions with vector value type",
+			supportedExprs: []ExprType{VectorSelector, AggregateExpr},
+			valueTypes:     []parser.ValueType{parser.ValueTypeVector},
+			wantNil:        false,
+		},
+		{
+			name:           "scalar only expressions with vector value type",
+			supportedExprs: []ExprType{NumberLiteral},
+			valueTypes:     []parser.ValueType{parser.ValueTypeVector},
+			wantNil:        true, // Should return nil as intersection is empty
+		},
+		{
+			name:           "mixed expressions with scalar value type",
+			supportedExprs: []ExprType{VectorSelector, NumberLiteral, BinaryExpr},
+			valueTypes:     []parser.ValueType{parser.ValueTypeScalar},
+			wantNil:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ps := New(
+				rand.New(rand.NewSource(1)), // Fixed seed for reproducibility
+				[]labels.Labels{labels.FromStrings("foo", "bar")},
+				WithEnabledExprs(tt.supportedExprs),
+			)
+
+			expr := ps.Walk(tt.valueTypes...)
+
+			if tt.wantNil {
+				if expr != nil {
+					t.Errorf("Walk() = %v, want nil", expr)
+				}
+				return
+			}
+
+			if expr == nil {
+				t.Fatal("Walk() returned nil, want non-nil expression")
+			}
+
+			// Verify the expression type matches one of the supported types
+			found := false
+			for _, supportedType := range tt.supportedExprs {
+				if exprMatchesType(expr, supportedType) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Walk() returned expression of unexpected type: %T", expr)
+			}
+		})
+	}
+}
+
+// Helper function to match expression types
+func exprMatchesType(expr parser.Expr, exprType ExprType) bool {
+	_, ok := expr.(*parser.ParenExpr)
+	if ok {
+		return true
+	}
+
+	switch exprType {
+	case VectorSelector:
+		_, ok := expr.(*parser.VectorSelector)
+		return ok
+	case NumberLiteral:
+		_, ok := expr.(*parser.NumberLiteral)
+		return ok
+	case BinaryExpr:
+		_, ok := expr.(*parser.BinaryExpr)
+		return ok
+	case AggregateExpr:
+		_, ok := expr.(*parser.AggregateExpr)
+		return ok
+	case CallExpr:
+		_, ok := expr.(*parser.Call)
+		return ok
+	case UnaryExpr:
+		_, ok := expr.(*parser.UnaryExpr)
+		return ok
+	case SubQueryExpr:
+		_, ok := expr.(*parser.SubqueryExpr)
+		return ok
+	case MatrixSelector:
+		_, ok := expr.(*parser.MatrixSelector)
+		return ok
+	default:
+		return false
+	}
+}
+
+func TestPromQLSmith_Walk_RespectsMaxDepth(t *testing.T) {
+	maxDepth := 5
+	ps := New(
+		rand.New(rand.NewSource(1)), // Fixed seed for reproducibility
+		testSeriesSet,
+		WithMaxDepth(maxDepth),
+	)
+
+	// Generate multiple expressions to increase confidence
+	for i := 0; i < 1000; i++ {
+		expr := ps.Walk()
+		fmt.Println(expr.Pretty(0))
+		depth := getExprDepth(expr)
+		require.LessOrEqual(t, depth, maxDepth, "expression depth %d exceeds maximum depth %d for expression: %s", depth, maxDepth, expr.String())
+	}
+}
+
+// getExprDepth returns the maximum depth of an expression tree
+func getExprDepth(expr parser.Expr) int {
+	if expr == nil {
+		return 0
+	}
+
+	switch e := expr.(type) {
+	case *parser.BinaryExpr:
+		return 1 + max(getExprDepth(e.LHS), getExprDepth(e.RHS))
+	case *parser.UnaryExpr:
+		return 1 + getExprDepth(e.Expr)
+	case *parser.ParenExpr:
+		return getExprDepth(e.Expr)
+	case *parser.AggregateExpr:
+		return 1 + getExprDepth(e.Expr)
+	case *parser.Call:
+		maxArgDepth := 0
+		for _, arg := range e.Args {
+			argDepth := getExprDepth(arg)
+			maxArgDepth = max(maxArgDepth, argDepth)
+		}
+		return 1 + maxArgDepth
+	case *parser.SubqueryExpr:
+		return 1 + getExprDepth(e.Expr)
+	case *parser.MatrixSelector:
+		return getExprDepth(e.VectorSelector)
+	default:
+		return 1
+	}
+}

--- a/walk_test.go
+++ b/walk_test.go
@@ -77,7 +77,7 @@ func TestWalkCall(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("test_case_%d", i), func(t *testing.T) {
-			expr := p.walkCall(tc.valueTypes...)
+			expr := p.walkCall(10, tc.valueTypes...)
 			c, ok := expr.(*parser.Call)
 			require.True(t, ok)
 			if len(tc.valueTypes) == 0 {
@@ -101,7 +101,7 @@ func TestWalkBinaryExpr(t *testing.T) {
 	rnd := rand.New(rand.NewSource(time.Now().Unix()))
 	opts := []Option{WithEnableOffset(true), WithEnableAtModifier(true)}
 	p := New(rnd, testSeriesSet, opts...)
-	expr := p.walkBinaryExpr(parser.ValueTypeVector, parser.ValueTypeScalar)
+	expr := p.walkBinaryExpr(10, parser.ValueTypeVector, parser.ValueTypeScalar)
 	result := expr.Pretty(0)
 	_, err := parser.ParseExpr(result)
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestWalkAggregateParam(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("test_case_%d", i), func(t *testing.T) {
-			expr := p.walkAggregateParam(tc.op)
+			expr := p.walkAggregateParam(tc.op, 10)
 			tc.expectedFunc(t, expr)
 		})
 	}
@@ -391,7 +391,7 @@ func TestWalkUnaryExpr(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("test_case_%d", i), func(t *testing.T) {
-			expr := p.walkUnaryExpr(tc.valueTypes...)
+			expr := p.walkUnaryExpr(10, tc.valueTypes...)
 			e, ok := expr.(*parser.UnaryExpr)
 			require.Equal(t, parser.ItemType(parser.SUB), e.Op)
 			require.True(t, ok)
@@ -420,7 +420,7 @@ func TestWalkFunctions(t *testing.T) {
 	p := New(rnd, testSeriesSet, opts...)
 	for _, f := range defaultSupportedFuncs {
 		call := &parser.Call{Func: f}
-		p.walkFunctions(call)
+		p.walkFunctions(call, 10)
 		for i, arg := range call.Args {
 			// Only happen for functions with variadic set to -1 like label_join.
 			// Hardcode its value to ensure it is string type.
@@ -479,7 +479,7 @@ func TestWalkAggregateExpr(t *testing.T) {
 	rnd := rand.New(rand.NewSource(time.Now().Unix()))
 	opts := []Option{WithEnableOffset(true), WithEnableAtModifier(true)}
 	p := New(rnd, testSeriesSet, opts...)
-	expr := p.walkAggregateExpr()
+	expr := p.walkAggregateExpr(10)
 	e, ok := expr.(*parser.AggregateExpr)
 	require.True(t, ok)
 	require.True(t, e.Op.IsAggregator())
@@ -550,7 +550,7 @@ func TestWalkHoltWinters(t *testing.T) {
 		Func: parser.Functions["holt_winters"],
 		Args: make([]parser.Expr, len(parser.Functions["holt_winters"].ArgTypes)),
 	}
-	p.walkHoltWinters(expr)
+	p.walkHoltWinters(expr, 10)
 	require.Equal(t, parser.ValueTypeMatrix, expr.Args[0].Type())
 	s1, ok := expr.Args[1].(*parser.NumberLiteral)
 	require.True(t, ok)
@@ -571,7 +571,7 @@ func TestWalkInfo(t *testing.T) {
 			Args: make([]parser.Expr, len(parser.Functions["info"].ArgTypes)),
 		}
 
-		p.walkInfo(expr)
+		p.walkInfo(expr, 10)
 		require.Equal(t, parser.ValueTypeVector, expr.Args[0].Type())
 		if len(expr.Args) == 2 {
 			_, ok := expr.Args[1].(*parser.VectorSelector)
@@ -774,7 +774,7 @@ func TestWalkSortByLabel(t *testing.T) {
 		expr := &parser.Call{
 			Func: f,
 		}
-		p.walkSortByLabel(expr)
+		p.walkSortByLabel(expr, 10)
 		require.Equal(t, expr.Args[0].Type(), f.ArgTypes[0])
 		for i := 1; i < len(expr.Args); i++ {
 			require.Equal(t, expr.Args[i].Type(), parser.ValueTypeString)
@@ -790,7 +790,7 @@ func TestWalkLabelJoin(t *testing.T) {
 	expr := &parser.Call{
 		Func: f,
 	}
-	p.walkLabelJoin(expr)
+	p.walkLabelJoin(expr, 10)
 	require.Equal(t, expr.Args[0].Type(), f.ArgTypes[0])
 	require.Equal(t, expr.Args[1].Type(), f.ArgTypes[1])
 	require.Equal(t, expr.Args[2].Type(), f.ArgTypes[2])
@@ -808,7 +808,7 @@ func TestWalkLabelReplace(t *testing.T) {
 		Func: f,
 		Args: make(parser.Expressions, len(f.ArgTypes)),
 	}
-	p.walkLabelReplace(expr)
+	p.walkLabelReplace(expr, 10)
 	for i := 0; i < len(expr.Args); i++ {
 		require.Equal(t, expr.Args[i].Type(), f.ArgTypes[i])
 	}


### PR DESCRIPTION
This PR fixes #2 

It has 2 main changes:
- Add `WithMaxDepth` to control the query generation depth
- When calling `walk` to generate an expression, both `valueTypes` and `supportedExprs` should be respected so we pick expression type that should satisfy both. If unable to find one, return nil.