### PR TITLE
generate number literal for topk parameter

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -79,7 +79,9 @@ func (s *PromQLSmith) walkGrouping() []string {
 func (s *PromQLSmith) walkAggregateParam(op parser.ItemType, depth int) parser.Expr {
 	switch op {
 	case parser.TOPK, parser.BOTTOMK:
-		return s.walk(depth, parser.ValueTypeScalar)
+		// s.walk prefers generating non-NumberLiteral for scalar.
+		// To simplify generated queries we hardcode number literal here.
+		return &parser.NumberLiteral{Val: float64(s.rnd.Intn(5) + 1)}
 	case parser.QUANTILE:
 		return s.walk(depth, parser.ValueTypeScalar)
 	case parser.COUNT_VALUES:


### PR DESCRIPTION
After we switch to `s.walk` it tries to not generate number literal for scalar type result when there are still choices available. As number literal is not that interesting.
However, for topk, bottomk scanario, it is kind of complex and very uncommon to not use number literal. So hard code a number literal here.