### PR TITLE
Improve vector matching for binary expression

### DIFF
--- a/walk_test.go
+++ b/walk_test.go
@@ -175,7 +175,7 @@ func TestWalkVectorMatching(t *testing.T) {
 	require.False(t, stop)
 	right, stop := getOutputSeries(rhs)
 	require.False(t, stop)
-	p.walkVectorMatching(binExpr, left, right, true)
+	p.walkVectorMatching(binExpr, left, right, true, true)
 	result := binExpr.Pretty(0)
 	_, err := parser.ParseExpr(result)
 	require.NoError(t, err)
@@ -183,7 +183,7 @@ func TestWalkVectorMatching(t *testing.T) {
 		Card:           parser.CardManyToOne,
 		On:             true,
 		MatchingLabels: []string{"method"},
-		Include:        []string{},
+		Include:        []string(nil),
 	}
 	require.Equal(t, expected, binExpr.VectorMatching)
 }


### PR DESCRIPTION
Improvement for binary expression vector matching:

- Allow creating `on` and `ignore` binary expression. Previously it was only `on`.
- Randomize match labels and include labels
- For simplicity, when vector matching is enabled, use vector selector as left and right child